### PR TITLE
add contextual params to nested render call

### DIFF
--- a/lit-any/render/index.js
+++ b/lit-any/render/index.js
@@ -1,9 +1,16 @@
 import { html } from 'lit-html';
 
 function recurseTemplates(registry, ignoreMissing, inheritedScope) {
-    return (value, currentScope) => {
+    return (value, currentScope, requestedParams) => {
         let templateResult;
-        const scope = currentScope || inheritedScope;
+        let scope;
+        let params = requestedParams;
+        if (typeof currentScope !== 'string') {
+            scope = inheritedScope;
+            params = currentScope;
+        } else {
+            scope = currentScope || inheritedScope;
+        }
         const template = registry.getTemplate({
             value,
             scope,
@@ -12,7 +19,7 @@ function recurseTemplates(registry, ignoreMissing, inheritedScope) {
         if (template) {
             const nextLevel = recurseTemplates(registry, ignoreMissing, scope);
 
-            templateResult = html`${template.render(value, nextLevel, scope)}`;
+            templateResult = html`${template.render(value, nextLevel, scope, params || {})}`;
         } else if (ignoreMissing) {
             templateResult = '';
         } else {

--- a/storybook/lit-view.stories.js
+++ b/storybook/lit-view.stories.js
@@ -1,13 +1,14 @@
 import { storiesOf } from '@storybook/polymer';
 import { html } from 'lit-html';
 import moment from 'moment';
-import { object } from '@storybook/addon-knobs';
+import { object, text } from '@storybook/addon-knobs';
 import '@lit-any/lit-any/lit-view';
 import ViewTemplates from '@lit-any/lit-any/views';
 import { defaultValue } from './knobs';
 import basic from './notes/lit-view/basic';
 import recursive from './notes/lit-view/recursive';
 import recursiveElements from './notes/lit-view/recursive-elements';
+import recursiveWithParams from './notes/lit-view/recursive-with-params';
 
 storiesOf('lit-view', module)
     .add('basic', () => {
@@ -71,4 +72,32 @@ storiesOf('lit-view/nesting', module)
 
         return recursiveElements(html`<lit-view .value="${defaultValue(object, value)}" 
                               template-registry="nested"></lit-view>`);
+    });
+
+storiesOf('lit-view/nesting', module)
+    .add('passing context params', () => {
+        ViewTemplates.byName('recursive-with-params')
+            .when
+            .valueMatches(value => value.type === 'Person')
+            .renders((person, render) => {
+                const params = {
+                    format: text('Date format', 'LL'),
+                };
+
+                return html`Hello, my name is ${person.fullName}. 
+                            I was born on ${render(person.birthDate, params)}`;
+            });
+
+        ViewTemplates.byName('recursive-with-params').when
+            .valueMatches(value => value instanceof Date || Date.parse(value))
+            .renders((date, next, scope, params) => html`${moment(date).format(params.format)}`);
+
+        const value = {
+            type: 'Person',
+            fullName: 'Louis Litt',
+            birthDate: new Date(1976, 8, 12),
+        };
+
+        return recursiveWithParams(html`<lit-view .value="${defaultValue(object, value)}" 
+                              template-registry="recursive-with-params"></lit-view>`);
     });

--- a/storybook/notes/lit-view/recursive-with-params.js
+++ b/storybook/notes/lit-view/recursive-with-params.js
@@ -1,0 +1,46 @@
+import { md, sample } from '../markdown';
+
+export default function notes(view) {
+    return md`# Optional parameters in child views
+    
+## Example
+
+${sample(view)}
+
+## Passing parameters to child view
+
+The render callback can use a fourth parameter which contains one-time parameters objects. It is passed to the recursive
+call to \`render\`. To continue pushing it deeper, it has to be explicitly forwarded by each nested view call.
+
+If missing, an empty object will be substituted.
+
+In the example below the top render function provides a moment date format string to be used for date formatting. 
+
+---js
+import { html } from 'lit-html'; 
+import moment from 'moment'; 
+import Registry from '@lit-any/lit-any/views';
+
+Registry.default
+    .when
+    .valueMatches(value => value.type === 'Person')
+    .renders((person, render) => {
+        const params = {
+            format: 'LL',
+        };
+
+        return html\`Hello, my name is $\{person.fullName}. 
+                    I was born on $\{render(person.birthDate, params)}\`;
+    });
+
+Registry.default
+    .when
+    .valueMatches(v => v instanceof Date || Date.parse(value))
+    .renders((date, next, scope, params) => html\`$\{moment(date).format(params.format)}\`);
+---
+
+Note that the \`params\` argument is placed second, where the scope typically resides. If the scope is also used, the
+call would be changed to \`render(person.birthDate, 'scope', params)\`.
+
+[sroot]: https://www.webcomponents.org/specs#the-shadow-dom-specification`;
+}

--- a/test/elements/lit-view.test.js
+++ b/test/elements/lit-view.test.js
@@ -230,4 +230,56 @@ describe('lit-view', () => {
             expect(span.textContent).to.equal('manually');
         });
     });
+
+    describe('when passing context values', () => {
+        beforeEach(() => {
+            getTemplate = sinon.stub();
+        });
+
+        beforeEach(async () => {
+            litView = await fixture('<lit-view></lit-view>');
+        });
+
+        it('makes it accessible to child render when used together with scope', async () => {
+            // given
+            getTemplate.returns({
+                render: (object, render, scope, params) => {
+                    if (params.sameToUpper) {
+                        return html`'${scope}' ${object.text.toUpperCase()}`;
+                    }
+
+                    return html`${object.text} ${render(object, 'bar', { sameToUpper: true })}`;
+                },
+            });
+            litView.value = { text: 'a' };
+            litView.templateScope = 'foo';
+
+            // when
+            await litView.updateComplete;
+
+            // then
+            expect(litView.shadowRoot.textContent).to.equal("a 'bar' A");
+        });
+
+        it('makes it accessible to child render when used without scope', async () => {
+            // given
+            getTemplate.returns({
+                render: (object, render, scope, params) => {
+                    if (params.sameToUpper) {
+                        return html`'${scope}' ${object.text.toUpperCase()}`;
+                    }
+
+                    return html`${object.text} ${render(object, { sameToUpper: true })}`;
+                },
+            });
+            litView.value = { text: 'a' };
+            litView.templateScope = 'foo';
+
+            // when
+            await litView.updateComplete;
+
+            // then
+            expect(litView.shadowRoot.textContent).to.equal("a 'foo' A");
+        });
+    });
 });

--- a/test/elements/lit-view.test.js
+++ b/test/elements/lit-view.test.js
@@ -188,6 +188,30 @@ describe('lit-view', () => {
             expect(getTemplate.secondCall.args[0].scope).to.equal('nested');
             expect(getTemplate.thirdCall.args[0].scope).to.equal('nested');
         });
+
+        it('should provide an empty params object fallback', async () => {
+            // given
+            getTemplate.returns({
+                render: (object, render, scope, params) => {
+                    if (object.child) {
+                        return html`<p>${render(object.child)}</p>`;
+                    }
+
+                    return html`<span>${JSON.stringify(params)}</span>`;
+                },
+            });
+            litView.value = {
+                child: {
+                },
+            };
+
+            // when
+            await litView.updateComplete;
+
+            // then
+            const span = litView.shadowRoot.querySelector('span');
+            expect(span.textContent).to.equal('{}');
+        });
     });
 
     describe('when template is not found', () => {

--- a/test/elements/lit-view.test.js
+++ b/test/elements/lit-view.test.js
@@ -231,7 +231,7 @@ describe('lit-view', () => {
         });
     });
 
-    describe('when passing context values', () => {
+    describe('when passing params values', () => {
         beforeEach(() => {
             getTemplate = sinon.stub();
         });


### PR DESCRIPTION
This adds contextual parameters which can affect how a recursive `render` is handled by next template function.